### PR TITLE
chore: remove -r / --region switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,8 @@ A script for editing Google Secret Manager Secrets in a manner consistent with o
 
 ### Secret Names
 
-The naming pattern is: `{env}-[{region}-]-gke-{secret}-secrets`
+The naming pattern is: `{env}-gke-{secret}-secrets`
 
-* `region` is optional
 * `secret` defaults to `app`
 
 ### Examples
@@ -32,12 +31,6 @@ $ python gsm.py view -p moz-fx-testapp1-nonprod -e stage
 
 ```bash
 $ python gsm.py view -p moz-fx-testapp1-nonprod -e stage -s cronjob-sync-something
-```
-
-#### view latest revision of moz-fx-testapp1-nonprod's app secrets for the stage env in region europe-west1:
-
-```bash
-$ python gsm.py view -p moz-fx-testapp1-nonprod -e stage -r europe-west1
 ```
 
 #### edit latest revision of moz-fx-testapp1-nonprod's app secrets for the stage env:

--- a/gsm.py
+++ b/gsm.py
@@ -26,8 +26,15 @@
 # that it would just time out. :(
 #
 
-import os, subprocess, argparse, tempfile, atexit, json, re
+import argparse
+import atexit
+import json
+import os
+import re
+import subprocess
+import tempfile
 from hashlib import sha256
+
 
 # thanks to https://www.quickprogrammingtips.com/python/how-to-calculate-sha256-hash-of-a-file-in-python.html
 def shasum(filename):
@@ -194,15 +201,6 @@ if __name__ == "__main__":
     )
 
     parser.add_argument(
-        "-r",
-        "--region",
-        type=str,
-        choices=["us-central1", "us-west1", "europe-west1"],
-        required=False,
-        help="optional region identifier",
-    )
-
-    parser.add_argument(
         "-s",
         "--secret",
         type=str,
@@ -221,12 +219,7 @@ if __name__ == "__main__":
     )
 
     args = parser.parse_args()
-
-    if args.region:
-        secret_name = f"{args.env}-{args.region}-gke-{args.secret}-secrets"
-
-    else:
-        secret_name = f"{args.env}-gke-{args.secret}-secrets"
+    secret_name = f"{args.env}-gke-{args.secret}-secrets"
 
     (tempfile_fd, tempfile_path) = tempfile.mkstemp()
 


### PR DESCRIPTION
Switch is superfluous, secret names can be customized with `-s` / `--secret`.