### PR TITLE
feat: Add diff as a subparser.

### DIFF
--- a/gsm_editor/commands.py
+++ b/gsm_editor/commands.py
@@ -8,6 +8,9 @@ from gsm_editor import utils
 from gsm_editor.exceptions import SecretNotFoundError
 from gsm_editor.models import CommandConfig, Secret
 
+# Create new secrets using this default string
+DEFAULT_SECRET_STRING = "{\n}\n"
+
 
 def edit_secret(config: CommandConfig):
     secret = Secret.from_command_config(config=config)
@@ -17,12 +20,14 @@ def edit_secret(config: CommandConfig):
             decoded_secret = utils.get_secret_version(secret=secret)
             secret_exists = True
         except SecretNotFoundError:
+            decoded_secret = DEFAULT_SECRET_STRING
             secret_exists = False
 
-        if secret_exists and decoded_secret:
-            # write decoded secret to temp file
-            with open(file, 'r+') as f:
-                f.write(decoded_secret)
+        # write decoded secret to temp file
+        with open(file, 'r+') as f:
+            f.write(decoded_secret)
+
+        if secret_exists:
             original_shasum = utils.shasum(file)
 
             # Open temp_file in editor

--- a/gsm_editor/commands.py
+++ b/gsm_editor/commands.py
@@ -1,0 +1,85 @@
+import difflib
+import pathlib
+import re
+import subprocess
+import tempfile
+
+from gsm_editor import utils
+from gsm_editor.exceptions import SecretNotFoundError
+from gsm_editor.models import CommandConfig, Secret
+
+
+def edit_secret(config: CommandConfig):
+    secret = Secret.from_command_config(config=config)
+    with tempfile.NamedTemporaryFile() as temporary_file:
+        file = pathlib.Path(temporary_file.name)
+        try:
+            decoded_secret = utils.get_secret_version(secret=secret)
+            secret_exists = True
+        except SecretNotFoundError:
+            secret_exists = False
+
+        if secret_exists and decoded_secret:
+            # write decoded secret to temp file
+            with open(file, 'r+') as f:
+                f.write(decoded_secret)
+            original_shasum = utils.shasum(file)
+
+            # Open temp_file in editor
+            utils.edit_secret_file(file=file)
+
+            new_shasum = utils.shasum(file)
+            if new_shasum != original_shasum:
+                utils.add_secret_version(secret=secret, file=file)
+            else:
+                print("No changes. Not pushing new version")
+
+        else:
+            utils.edit_secret_file(file=file)
+            utils.create_secret(secret=secret, file=file)
+
+
+def view_secret(config: CommandConfig):
+    secret = Secret.from_command_config(config=config)
+    decoded_secret = utils.get_secret_version(secret=secret)
+    print(decoded_secret)
+
+
+def list_secrets(config: CommandConfig):
+    secret = Secret.from_command_config(config=config)
+    subprocess.call(
+        ["gcloud", "--project", secret.project_id, "secrets", "versions", "list",
+         secret.secret_name]
+    )
+
+
+def name_secrets(config: CommandConfig):
+    secret = Secret.from_command_config(config=config)
+    full_names = subprocess.run(
+        ["gcloud", "--project", secret.project_id, "secrets", "list",
+         "--format=get(name)"],
+        capture_output=True,
+        text=True,
+    )
+    result = re.findall(rf"(?<={secret.env}-gke-)(.*)(?=-secrets)", full_names.stdout)
+    print("\n".join(map(str, result)))
+
+
+def diff_secrets(config: CommandConfig, version_a: str, version_b: str):
+    secret_a = Secret(project_id=config.project_id, env=config.env, secret_id=config.secret_id, version=version_a)
+    secret_b = Secret(project_id=config.project_id, env=config.env, secret_id=config.secret_id, version=version_b)
+
+    decoded_secret_a = utils.get_secret_version(secret=secret_a).splitlines(keepends=True)
+    decoded_secret_b = utils.get_secret_version(secret=secret_b).splitlines(keepends=True)
+
+    diff = []
+    for line in difflib.unified_diff(
+            decoded_secret_a, decoded_secret_b,
+            fromfile=str(secret_a),
+            tofile=str(secret_b),
+            lineterm=""):
+        diff.append(line)
+    if diff:
+        print("\n".join(diff))
+    else:
+        print(f"No differences between `{str(secret_a)}` and `{str(secret_b)}`.")

--- a/gsm_editor/exceptions.py
+++ b/gsm_editor/exceptions.py
@@ -1,0 +1,2 @@
+class SecretNotFoundError(Exception):
+    pass

--- a/gsm_editor/models.py
+++ b/gsm_editor/models.py
@@ -1,0 +1,56 @@
+import base64
+from argparse import Namespace
+from dataclasses import dataclass
+
+
+@dataclass
+class CommandConfig:
+    action: str
+    project_id: str
+    env: str
+    secret_id: str | None
+    version: str | None
+
+    @classmethod
+    def from_parser_args(cls, parser_args: Namespace) -> 'CommandConfig':
+        # Deal with optional arguments
+        secret_id = parser_args.secret if "secret" in parser_args else None
+        version = parser_args.version if "version" in parser_args else None
+        return CommandConfig(action=parser_args.action,
+                             project_id=parser_args.project,
+                             env=parser_args.env,
+                             secret_id=secret_id,
+                             version=version,
+                             )
+
+
+@dataclass
+class Secret:
+    project_id: str
+    env: str
+    secret_id: str | None
+    version: str | None
+
+    @classmethod
+    def decode_raw_bytes_secret(cls, input_bytes: bytes) -> str:
+        # to deal with possible binary data, google suggests the following transforms:
+        # (see: https://cloud.google.com/sdk/gcloud/reference/secrets/versions/access)
+        # Replaces ('_') with ('/') and ('-') with ('+')
+        translation_table = bytes.maketrans(b'_-', b'/+')
+        translated_result = input_bytes.translate(translation_table)
+        return base64.b64decode(translated_result).decode("utf8")
+
+    @property
+    def secret_name(self) -> str:
+        return f"{self.env}-gke-{self.secret_id}-secrets"
+
+    def __str__(self) -> str:
+        return f"{self.project_id}/{self.secret_name}:{self.version}"
+
+    @classmethod
+    def from_command_config(cls, config: CommandConfig) -> 'Secret':
+        return Secret(project_id=config.project_id,
+                      env=config.env,
+                      secret_id=config.secret_id,
+                      version=config.version,
+                      )

--- a/gsm_editor/utils.py
+++ b/gsm_editor/utils.py
@@ -1,0 +1,114 @@
+import json
+import os
+import subprocess
+from hashlib import sha256
+
+import pathlib
+
+from gsm_editor.exceptions import SecretNotFoundError
+from gsm_editor.models import Secret
+
+
+# thanks to https://www.quickprogrammingtips.com/python/how-to-calculate-sha256-hash-of-a-file-in-python.html
+def shasum(file: pathlib.Path):
+    sha256_hash = sha256()
+    with open(file, "rb") as f:
+        # Read and update hash string value in blocks of 4K
+        for byte_block in iter(lambda: f.read(4096), b""):
+            sha256_hash.update(byte_block)
+    return sha256_hash.hexdigest()
+
+
+def create_secret(secret: Secret, file: pathlib.Path):
+    """
+    Create a new secret with the given name. A secret is a logical wrapper
+    around a collection of secret versions. Secret versions hold the actual
+    secret material.
+    """
+
+    # FIXME: is an exception raised if this fails? if not, then look at return code
+    subprocess.run(
+        [
+            "gcloud",
+            "--project",
+            secret.project_id,
+            "secrets",
+            "create",
+            secret.secret_name,
+            "--data-file",
+            file,
+        ]
+    )
+
+
+def add_secret_version(secret: Secret, file: pathlib.Path):
+    """
+    Add a new secret version to the given secret with the provided payload.
+    """
+
+    # FIXME: is an exception raised if this fails? if not, then look at return code
+    subprocess.run(
+        [
+            "gcloud",
+            "--project",
+            secret.project_id,
+            "secrets",
+            "versions",
+            "add",
+            secret.secret_name,
+            "--data-file",
+            file,
+        ]
+    )
+
+
+def get_secret_version(secret: Secret) -> str:
+    """
+    Get secret version content and return UTF8 encoded string
+    """
+
+    result = subprocess.run(
+        [
+            "gcloud",
+            "--project",
+            secret.project_id,
+            "secrets",
+            "versions",
+            "access",
+            secret.version,
+            "--secret",
+            secret.secret_name,
+            "--format=get(payload.data)",
+        ],
+        stdout=subprocess.PIPE,
+    )
+    try:
+        assert result.returncode != 1
+    except AssertionError as e:
+        raise SecretNotFoundError(f"Error fetching `{str(secret)}`") from e
+
+    return Secret.decode_raw_bytes_secret(input_bytes=result.stdout)
+
+
+def edit_secret_file(file: pathlib.Path):
+    editor = os.getenv("EDITOR", "vi")
+
+    valid_json = False
+    while True:
+        subprocess.call(f"{editor} {file}", shell=True)
+        # TODO: validate exit status?
+        # TODO: add an option to skip validation
+        try:
+            with open(file) as f:
+                json.load(f)
+            valid_json = True
+            break
+        except json.decoder.JSONDecodeError as e:
+            print(e)
+            again = input("Try again [Y/n]: ")
+            if again != "Y" and again != "":
+                break
+
+    if not valid_json:
+        raise Exception("Unable to validate JSON")
+


### PR DESCRIPTION
# Description
This implements `diff` action. I had to rewrite the script to use subparsers because the syntax for diff required two positional arguments, which was not really compatible with the previous implementation. This lead to a significant refactoring to decouple the code a bit.

Also adds a default empty JSON string when creating a new secret :point_down: 
```json
{
}
```

# Usage
```
❯ ./gsm.py diff 3 latest -p moz-fx-project-dev -e dev
--- moz-fx-project-dev/dev-gke-app-secrets:1  
+++ moz-fx-project-dev/dev-gke-app-secrets:latest
@@ -1,3 +1,3 @@
 {

-    "test": "secret3"

+    "test": "secret4"

 }
```

# Validation

- [x] Can create new secrets
- [x] Can edit existing secret
- [x] Push a new version if secret was changed
- [x] Can list secrets
- [x] Can list secret names
- [x] Can view secrets
- [x] Can diff two versions of the same secret

# Related Issues
Closes https://github.com/mozilla-it/gsm-editor/issues/6 
Closes https://github.com/mozilla-it/gsm-editor/issues/5