### PR TITLE
Support a user entering lower-case 'y' to try again upon editing problems

### DIFF
--- a/gsm_editor/utils.py
+++ b/gsm_editor/utils.py
@@ -106,7 +106,7 @@ def edit_secret_file(file: pathlib.Path):
         except json.decoder.JSONDecodeError as e:
             print(e)
             again = input("Try again [Y/n]: ")
-            if again != "Y" and again != "":
+            if again.upper() != "Y" and again != "":
                 break
 
     if not valid_json:


### PR DESCRIPTION
This bit me hard when creating a long new secret that had a JSON error in it. I got the "Try again [Y/n]:" prompt and hit `y`, which then was taken as 'No, don't try again', losing all my work.

I know the prompt is clear about what value to enter (`Y`), but a little latitude here is worthwhile, I think